### PR TITLE
version bump, draft release

### DIFF
--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "super-controller",
   "productName": "SuperController",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Give your MIDI devices super powers; take control of the lights, messages, and communications between controllers.",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Prepare v2.0.0 release. Internal testing required prior to wide-scale rollout